### PR TITLE
Add the possibility to change the orientation of Menu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,16 +24,11 @@ pub struct MenuState<T> {
 }
 
 /// Orientation of [Menu] which is configurable in [MenuState]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum MenuOrientation {
     Left,
+    #[default]
     Right,
-}
-
-impl Default for MenuOrientation {
-    fn default() -> Self {
-        Self::Right
-    }
 }
 
 impl MenuOrientation {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1be971d4-ff50-49ee-8092-7a48c5a608b8)
It also closes #4 
It's weird to have .set_orientation(...) on MenuState instead of just Menu, but since it affects MenuState::right(), MenuState::left() I think it has to be this way?

I'm also wondering whether MenuState::set_orientation(...) should take mut self or a &mut self, the second option would allow the user to adjust the orientation more easily when the program is running for example when there is not enough space on one side but there is on the other