### PR TITLE
ci: don't run release-plz on pull requests

### DIFF
--- a/.github/workflows/rust-release-plz.yml
+++ b/.github/workflows/rust-release-plz.yml
@@ -10,8 +10,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-
 jobs:
   release-plz:
     name: Release-plz


### PR DESCRIPTION
The release workflow only needs to be run once code is merged to main. It causes errors in the checks if not.