### PR TITLE
Add a border to menus (issue #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Border around drop down menus
+
 ## [0.3.0](https://github.com/shuoli84/tui-menu/compare/v0.2.4...v0.3.0) - 2024-12-09
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A menu widget for [Ratatui](https://crates.io/crates/ratatui).
 
-![Demo](https://vhs.charm.sh/vhs-3pN84WzBTmPTbU2SCtvUiV.gif)
-
+![Demo](https://vhs.charm.sh/vhs-73WyYtjPZG8s9uOuEspiD7.gif)
 ## Features
 
 - Sub menu groups.

--- a/demo.tape
+++ b/demo.tape
@@ -68,21 +68,26 @@ Show
 Set TypingSpeed 500ms
 
 # File | Open recent | file_1.txt
-Right Down 3 Right
+Down 4 Right
 # screenshot for ratatui.rs showcase
 Sleep 100ms Screenshot target/demo.png
 Enter Sleep 1s
 
 # File | Open recent | file_2.txt
-Right Down 3 Right Down Enter Sleep 1s
+Down 4 Right Down Enter Sleep 1s
 
 # Show off other menus
-Right 3 Left 2
+Down Right 2 Left 2
+Escape
+Sleep 1s
 
 # File | Exit
-Down 5 Enter
+Set TypingSpeed 200ms
+Down 6
+Sleep 500ms
+Enter
 
 # Show that the app exited before repeating the animation
-Sleep 1s
+Sleep 3s
 Hide
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -113,7 +113,7 @@ enum Action {
 impl App {
     fn run<B: Backend>(mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
         loop {
-            terminal.draw(|frame| frame.render_widget(&mut self, frame.size()))?;
+            terminal.draw(|frame| frame.render_widget(&mut self, frame.area()))?;
 
             if event::poll(std::time::Duration::from_millis(10))? {
                 if let Event::Key(key) = event::read()? {

--- a/examples/nested_group.rs
+++ b/examples/nested_group.rs
@@ -102,7 +102,7 @@ enum Action {
 impl App {
     fn run<B: Backend>(mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
         loop {
-            terminal.draw(|frame| frame.render_widget(&mut self, frame.size()))?;
+            terminal.draw(|frame| frame.render_widget(&mut self, frame.area()))?;
 
             if event::poll(std::time::Duration::from_millis(10))? {
                 if let Event::Key(key) = event::read()? {
@@ -139,7 +139,7 @@ impl App {
 impl Widget for &mut App {
     fn render(self, area: Rect, buf: &mut Buffer) {
         use Constraint::*;
-        let [top, main] = Layout::vertical([Length(1), Fill(1)]).areas(area);
+        let [_top, main] = Layout::vertical([Length(1), Fill(1)]).areas(area);
 
         Paragraph::new(self.content.as_str())
             .block(Block::bordered().title("Content").on_black())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,12 @@ will be stored in MenuState.events.
 To define a menu, see examples in [MenuState].
 */
 
-#![allow(dead_code)]
-
 use ratatui::{
     layout::Rect,
+    prelude::*,
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Clear, StatefulWidget, Widget},
+    widgets::{Block, Borders, Clear, StatefulWidget, Widget},
 };
 use std::{borrow::Cow, marker::PhantomData};
 
@@ -603,8 +602,11 @@ impl<T> Menu<T> {
             .map(|menu_item| Span::from(menu_item.name.clone()).width())
             .max()
             .unwrap_or(0) as u16;
-        let min_drop_down_width: u16 = child_max_width + 6;
-        let min_drop_down_height: u16 = (group.len() as u16) + 2;
+
+        // Compute minimum size needed after border is added
+        // Border is 3 chars wide and 1 char high, on both sides.
+        let min_drop_down_width: u16 = child_max_width + 3 + 3;
+        let min_drop_down_height: u16 = (group.len() as u16) + 1 + 1;
 
         // prevent calculation issue if canvas is narrow
         let drop_down_width = self.drop_down_width.min(buf.area.width);
@@ -629,9 +631,6 @@ impl<T> Menu<T> {
         buf.set_style(area, self.default_item_style);
 
         // Render menu border
-        use ratatui::prelude::Margin;
-        use ratatui::widgets::Block;
-        use ratatui::widgets::Borders;
         let border = Block::default()
             .borders(Borders::ALL)
             .style(self.default_item_style);


### PR DESCRIPTION
This implements the following features found in cursive menus
- [x] Border on drop down menus
- [ ] Shadow on drop down menus
- [ ] Scrollbar on long menus
